### PR TITLE
Switch to a 2-split scaffold, allowing config-suite to be enabled after everything else.

### DIFF
--- a/assets/config-local/config_suite.settings.yml
+++ b/assets/config-local/config_suite.settings.yml
@@ -1,2 +1,0 @@
-automatic_import: false
-automatic_export: true

--- a/assets/config-split/config-suite/.htaccess
+++ b/assets/config-split/config-suite/.htaccess
@@ -7,6 +7,7 @@
 <IfModule !mod_authz_core.c>
   Deny from all
 </IfModule>
+
 # Turn off all options we don't need.
 Options -Indexes -ExecCGI -Includes -MultiViews
 
@@ -18,6 +19,6 @@ SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
 </Files>
 
 # If we know how to do it safely, disable the PHP engine entirely.
-<IfModule mod_php5.c>
+<IfModule mod_php7.c>
   php_flag engine off
 </IfModule>

--- a/assets/config-split/config-suite/config_suite.settings.yml
+++ b/assets/config-split/config-suite/config_suite.settings.yml
@@ -1,0 +1,10 @@
+_core:
+  default_config_hash: ScY2YofVIGMVG0t-BTzj9sB882Thr9ShbXc5TcVyiAA
+automatic_import: false
+automatic_export: true
+dependencies:
+  module:
+    - config_suite
+  enforced:
+    module:
+      - config_suite

--- a/assets/config-split/local/.htaccess
+++ b/assets/config-split/local/.htaccess
@@ -1,0 +1,24 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>

--- a/assets/config-split/local/stage_file_proxy.settings.yml
+++ b/assets/config-split/local/stage_file_proxy.settings.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: wB2h-QBawANCiCVEXy6bJjiDfvZY6EONZ6-wRB_RYQc
+hotlink: false
+origin: 'https://live-lppi.pantheonsite.io'
+origin_dir: ''
+use_imagecache_root: true
+verify: true

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
                     "path": "assets/.github/ISSUE_TEMPLATE/feature_request.md",
                     "overwrite": false
                 },
-                "[project-root]/config-local/config_suite.settings.yml": "assets/config-local/config_suite.settings.yml",
+                "[project-root]/config-split/config-suite/config_suite.settings.yml": "assets/config-split/config-suite/config_suite.settings.yml",
+                "[project-root]/config-split/local/stage_file_proxy.settings.yml": "assets/config-split/local/stage_file_proxy.settings.yml",
                 "[project-root]/env.dist": {
                     "path": "assets/.env.dist",
                     "overwrite": false

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
                 },
                 "[project-root]/config-split/config-suite/config_suite.settings.yml": "assets/config-split/config-suite/config_suite.settings.yml",
                 "[project-root]/config-split/local/stage_file_proxy.settings.yml": "assets/config-split/local/stage_file_proxy.settings.yml",
-                "[project-root]/env.dist": {
+                "[project-root]/.env.dist": {
                     "path": "assets/.env.dist",
                     "overwrite": false
                 },


### PR DESCRIPTION
This setup (which also requires setting up config-splits appropriately, with different weights), fixes the issue where fresh site setups move configurations out of the "split" directory and into the regular config directory.