### PR TITLE
Scaffold the dotenv helper file.

### DIFF
--- a/assets/load.environment.php
+++ b/assets/load.environment.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is included very early. See autoload.files in composer.json and
+ * https://getcomposer.org/doc/04-schema.md#files
+ */
+
+use Dotenv\Dotenv;
+
+/**
+ * Load any .env file. See /.env.example.
+ *
+ * Drupal has no official method for loading environment variables and uses
+ * getenv() in some places.
+ */
+$dotenv = Dotenv::createUnsafeImmutable(__DIR__);
+$dotenv->safeLoad();

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,9 @@
     "conflict": {
         "drupal/core": "<9"
     },
+    "require": {
+        "vlucas/phpdotenv": ">=5.0",
+    },
     "extra": {
         "drupal-scaffold": {
             "file-mapping": {
@@ -30,6 +33,10 @@
                 "[project-root]/.env.dist": {
                     "path": "assets/.env.dist",
                     "overwrite": false
+                },
+                "[project-root]/load.environment.php": {
+                    "path": "assets/load.environment.php",
+                    "overwrite": true
                 },
                 "[project-root]/README.md": {
                     "path": "assets/README.md",


### PR DESCRIPTION
This adds a requirement for dotenv to avoid a situation where this new "load.environment.php" gets pulled into a site with the old version of dotenv. Wrong way to do this perhaps? Maybe it should just be a conflict?

Anyway, this would suggest doing a release before merging this and a release after so sites can use numbered releases of this project.

Note that I chose to do "overwrite: true" for this particular file.