### PR TITLE
Creating a settings.dev.php default.

### DIFF
--- a/assets/web/sites/default/settings.dev.php
+++ b/assets/web/sites/default/settings.dev.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @file
+ * Local development override configuration feature.
+ *
+ * To activate this feature, copy and rename it such that its path plus
+ * filename is 'sites/default/settings.local.php'. Then, go to the bottom of
+ * 'sites/default/settings.php' and uncomment the commented lines that mention
+ * 'settings.local.php'.
+ *
+ * If you are using a site name in the path, such as 'sites/example.com', copy
+ * this file to 'sites/example.com/settings.local.php', and uncomment the lines
+ * at the bottom of 'sites/example.com/settings.php'.
+ */
+
+/**
+ * Assertions.
+ *
+ * The Drupal project primarily uses runtime assertions to enforce the
+ * expectations of the API by failing when incorrect calls are made by code
+ * under development.
+ *
+ * @see http://php.net/assert
+ * @see https://www.drupal.org/node/2492225
+ *
+ * If you are using PHP 7.0 it is strongly recommended that you set
+ * zend.assertions=1 in the PHP.ini file (It cannot be changed from .htaccess
+ * or runtime) on development machines and to 0 in production.
+ *
+ * @see https://wiki.php.net/rfc/expectations
+ */
+assert_options(ASSERT_ACTIVE, TRUE);
+\Drupal\Component\Assertion\Handle::register();
+
+/**
+ * Enable local development services.
+ */
+$settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
+
+/**
+ * Show all error messages, with backtrace information.
+ *
+ * In case the error level could not be fetched from the database, as for
+ * example the database connection failed, we rely only on this value.
+ */
+$config['system.logging']['error_level'] = 'verbose';
+
+/**
+ * Disable CSS and JS aggregation.
+ */
+$config['system.performance']['css']['preprocess'] = FALSE;
+$config['system.performance']['js']['preprocess'] = FALSE;
+
+/**
+ * Disable the render cache (this includes the page cache).
+ *
+ * Note: you should test with the render cache enabled, to ensure the correct
+ * cacheability metadata is present. However, in the early stages of
+ * development, you may want to disable it.
+ *
+ * This setting disables the render cache by using the Null cache back-end
+ * defined by the development.services.yml file above.
+ *
+ * Do not use this setting until after the site is installed.
+ */
+$settings['cache']['bins']['render'] = 'cache.backend.null';
+
+/**
+ * Disable Dynamic Page Cache.
+ *
+ * Note: you should test with Dynamic Page Cache enabled, to ensure the correct
+ * cacheability metadata is present (and hence the expected behavior). However,
+ * in the early stages of development, you may want to disable it.
+ */
+$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+
+/**
+ * Allow test modules and themes to be installed.
+ *
+ * Drupal ignores test modules and themes by default for performance reasons.
+ * During development it can be useful to install test extensions for debugging
+ * purposes.
+ */
+$settings['extension_discovery_scan_tests'] = FALSE;
+
+/**
+ * Enable access to rebuild.php.
+ *
+ * This setting can be enabled to allow Drupal's php and database cached
+ * storage to be cleared via the rebuild.php page. Access to this page can also
+ * be gained by generating a query string from rebuild_token_calculator.sh and
+ * using these parameters in a request to rebuild.php.
+ */
+$settings['rebuild_access'] = TRUE;
+
+/**
+ * Skip file system permissions hardening.
+ *
+ * The system module will periodically check the permissions of your site's
+ * site directory to ensure that it is not writable by the website user. For
+ * sites that are managed with a version control system, this can cause problems
+ * when files in that directory such as settings.php are updated, because the
+ * user pulling in the changes won't have permissions to modify files in the
+ * directory.
+ */
+$settings['skip_permissions_hardening'] = TRUE;
+
+// Check for custom DRUPAL_INSTALL environment variable (set in
+// drush/SITE.drush.inc) OR $is_installer_url (set in settings.pantheon.php)
+// to determine if we should enable file base config.
+if (!(getenv('DRUPAL_INSTALL') || $is_installer_url)) {
+  // Add a services file to set dev settings.
+  $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/default/services.dev.yml';
+}

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,10 @@
                     "path": "assets/web/sites/default/settings.php",
                     "overwrite": false
                 },
+                "[web-root]/sites/default/settings.dev.php": {
+                    "path": "assets/web/sites/default/settings.dev.php",
+                    "overwrite": false
+                },
                 "[web-root]/sites/default/settings.ts.php": "assets/web/sites/default/settings.ts.php",
                 "[web-root]/sites/default/services.dev.yml": "assets/web/sites/default/services.dev.yml",
                 "[web-root]/modules/contrib/ts_styleguide/src/Controller/StyleGuideController.php": "assets/web/modules/contrib/ts_styleguide/src/Controller/StyleGuideController.php",


### PR DESCRIPTION
Adds the settings.dev.php file that is missing right now.

To test:
- [x] In another repo, delete your `web/sites/default/settings.dev.php` file.
- [x] Composer require this branch: `composer require thinkshout/drupal-integrations:dev-issue-3`

You should have your settings.dev.php file back.