### PR TITLE
Adding a theme component to the styleguide so it can render twig temp…

### DIFF
--- a/assets/web/modules/thinkshout/ts_styleguide/src/Controller/StyleGuideController.php
+++ b/assets/web/modules/thinkshout/ts_styleguide/src/Controller/StyleGuideController.php
@@ -46,29 +46,10 @@ class StyleGuideController extends ControllerBase {
    */
   public function tsStyleGuide() {
     $themename = $this->configFactory->get('system.theme')->get('default');
-    try {
-      $template = $this->twig->load("@$themename/_includes/styleguide.html.twig");
-    }
-    catch (LoaderError $e) {
-      return [
-        '#markup' => $this->t('The current theme "@theme" does not have a template at templates/_includes/styleguide.html', ['@theme' => $themename]),
-      ];
-    }
-    $context = [];
-    $allowed_tags = array_merge(Xss::getAdminTagList(),
-          [
-            'form',
-            'label',
-            'input',
-            'select',
-            'option',
-            'radio',
-            'fieldset',
-            'legend',
-          ]);
+
     return [
-      '#markup' => $template->render($context),
-      '#allowed_tags' => $allowed_tags,
+      '#theme' => 'styleguide',
+      '#theme_name' => $themename,
     ];
   }
 

--- a/assets/web/modules/thinkshout/ts_styleguide/templates/styleguide.html.twig
+++ b/assets/web/modules/thinkshout/ts_styleguide/templates/styleguide.html.twig
@@ -1,0 +1,2 @@
+{# This twig template just exists to be overridden by your theme. #}
+<p>Overwrite this template by creating a "styleguide.html.twig" file in your {{ theme_name }} theme.</p>

--- a/assets/web/modules/thinkshout/ts_styleguide/ts_styleguide.module
+++ b/assets/web/modules/thinkshout/ts_styleguide/ts_styleguide.module
@@ -1,0 +1,15 @@
+<?php
+use Drupal\Core\Render\Element;
+
+/**
+ * Implements hook_theme().
+ */
+function ts_styleguide_theme() {
+  return [
+    'styleguide' => [
+      'variables' => [
+        'theme_name' => NULL,
+      ],
+    ],
+  ];
+}

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,9 @@
                 "[web-root]/sites/default/settings.ts.php": "assets/web/sites/default/settings.ts.php",
                 "[web-root]/sites/default/services.dev.yml": "assets/web/sites/default/services.dev.yml",
                 "[web-root]/modules/thinkshout/ts_styleguide/src/Controller/StyleGuideController.php": "assets/web/modules/thinkshout/ts_styleguide/src/Controller/StyleGuideController.php",
+                "[web-root]/modules/thinkshout/ts_styleguide/templates/styleguide.html.twig": "assets/web/modules/thinkshout/ts_styleguide/templates/styleguide.html.twig",
                 "[web-root]/modules/thinkshout/ts_styleguide/ts_styleguide.info.yml": "assets/web/modules/thinkshout/ts_styleguide/ts_styleguide.info.yml",
+                "[web-root]/modules/thinkshout/ts_styleguide/ts_styleguide.module": "assets/web/modules/thinkshout/ts_styleguide/ts_styleguide.module",
                 "[web-root]/modules/thinkshout/ts_styleguide/ts_styleguide.routing.yml": "assets/web/modules/thinkshout/ts_styleguide/ts_styleguide.routing.yml"
             }
         }


### PR DESCRIPTION
…lates without running them through a markup filter.

This lets you include regular template files in your styleguide for things like blocks.

PR can be reviewed here in action: https://github.com/thinkshout/ccal/pull/212

You have to delete your site's thinkshout/ts_styleguide module to get the changes to take, likely.