### PR TITLE
Remove default redis config, which can cause permanent WSOD on pantheon

### DIFF
--- a/assets/web/sites/default/settings.ts.php
+++ b/assets/web/sites/default/settings.ts.php
@@ -14,28 +14,6 @@ else {
   $config['config_split.config_split.local']['status'] = TRUE;
 }
 
-// If we are not installing and have a redis host defined, setup redis.
-if (!(getenv('DRUPAL_INSTALL') || $is_installer_url) && defined('PANTHEON_ENVIRONMENT') && !empty($conf['redis_client_host'])) {
-  // Include the Redis services.yml file. Adjust the path if you installed to a contrib or other subdirectory.
-  $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
-
-  // PhpRedis is built into the Pantheon application container.
-  $settings['redis.connection']['interface'] = 'PhpRedis';
-  // These are dynamic variables handled by Pantheon.
-  $settings['redis.connection']['host']      = $_ENV['CACHE_HOST'];
-  $settings['redis.connection']['port']      = $_ENV['CACHE_PORT'];
-  $settings['redis.connection']['password']  = $_ENV['CACHE_PASSWORD'];
-
-  $settings['cache']['default'] = 'cache.backend.redis'; // Use Redis as the default cache.
-  $settings['cache_prefix']['default'] = 'pantheon-redis';
-
-  $settings['redis_compress_length'] = 100;
-  $settings['redis_compress_level'] = 1;
-
-  // Set Redis to not get the cache_form (no performance difference).
-  $settings['cache']['bins']['form']      = 'cache.backend.database';
-}
-
 $settings['install_profile'] = 'minimal';
 
 // Require HTTPS.


### PR DESCRIPTION
Proposal to delete this default code. Open to other ideas though! I expected to be able to enable Redis on the Pantheon dashboard without any consequences, but here's what happened on my site:

1. I enabled Redis on the pantheon dashboard
2. All sites started showing WSOD
3. I panicked
4. I disabled Redis on the pantheon dashboard
5. All sites continued to show WSOD

I believe this is because Pantheon leaves the `$conf['redis_client_host']` setting even after Redis has been disabled, but I honestly couldn't confirm that while panicking...