### PR TITLE
Fixing segfault 11 error on pantheon sites that are using integrated …

### DIFF
--- a/assets/load.environment.php
+++ b/assets/load.environment.php
@@ -13,5 +13,7 @@ use Dotenv\Dotenv;
  * Drupal has no official method for loading environment variables and uses
  * getenv() in some places.
  */
-$dotenv = Dotenv::createUnsafeImmutable(__DIR__);
-$dotenv->safeLoad();
+if (!defined('PANTHEON_ENVIRONMENT')) {
+  $dotenv = Dotenv::createUnsafeImmutable(__DIR__);
+  $dotenv->safeLoad();
+}


### PR DESCRIPTION
…composer.

On Pantheon, they build using the "-dev" sections until they push to test/live. This meant they were trying to pull in our `.env` file and we don't want that.

The  syntax here mirrors that of  https://github.com/thinkshout/drupal-integrations/blob/main/assets/web/sites/default/settings.php#L6