### PR TITLE
Make both styleguide paths available.

### DIFF
--- a/assets/web/modules/thinkshout/ts_styleguide/ts_styleguide.routing.yml
+++ b/assets/web/modules/thinkshout/ts_styleguide/ts_styleguide.routing.yml
@@ -1,7 +1,15 @@
 ts_styleguide.ts_style_guide:
+  path: '/style-guide'
+  defaults:
+    _controller: 'Drupal\ts_styleguide\Controller\StyleGuideController::tsStyleGuide'
+    _title: 'TS Style Guide'
+  requirements:
+    _custom_access: 'Drupal\ts_styleguide\Controller\StyleGuideController::tsStyleGuideAccess'
+
+ts_styleguide.ts_styleguide:
   path: '/styleguide'
   defaults:
     _controller: 'Drupal\ts_styleguide\Controller\StyleGuideController::tsStyleGuide'
-    _title: 'ts Style Guide'
+    _title: 'TS Style Guide'
   requirements:
     _custom_access: 'Drupal\ts_styleguide\Controller\StyleGuideController::tsStyleGuideAccess'


### PR DESCRIPTION
Our standard styleguide path on WP builds these days is `/style-guide`. @JulesKhong requested I use the same for CBC, but it depends on this project which uses `/styleguide`. If we change it here, we may disrupt expectations of other sites using that path.

As a convenient workaround, then, why not just do both?