### PR TITLE
Add dotenv requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         ]
     },
     "require": {
-        "thinkshout/ts_styleguide": "^1.0"
+        "thinkshout/ts_styleguide": "^1.0",
+        "vlucas/phpdotenv": ">=5.0"
     }
 }


### PR DESCRIPTION
This doesn't usually come up because thinkshout/robo-drupal provides this package. But we have a 'use' statement that requires dotenv in load.environment.php, so if you install this package before you install robo-drupal you break your site. I supposed we could also require ts/robo-drupal instead, but this seemed more direct.