### PR TITLE
Instructions for bypassing pantheon interstitial.

### DIFF
--- a/assets/.ci/test/visual-regression/README.md
+++ b/assets/.ci/test/visual-regression/README.md
@@ -10,7 +10,7 @@ module.exports = async (page, scenario, vp) => {
 ```
 
 In your backstopConfig.js, add this in your scenariosToTest push arguments after `misMatchThreshold`:
-`onBeforeScript: "onBefore.js",`
+`onBeforeScript: "bypassInterstitial.js",`
 
 ## How to use backstopjs:
 

--- a/assets/.ci/test/visual-regression/README.md
+++ b/assets/.ci/test/visual-regression/README.md
@@ -1,3 +1,17 @@
+## How to bypass Pantheon's interstitial:
+Create a file at `backstop_data/engine_scripts/bypassInterstitial.js` containing this:
+
+```js
+module.exports = async (page, scenario, vp) => {
+    await page.setExtraHTTPHeaders({
+        'Deterrence-Bypass': '1',
+    });
+};
+```
+
+In your backstopConfig.js, add this in your scenariosToTest push arguments after `misMatchThreshold`:
+`onBeforeScript: "onBefore.js",`
+
 ## How to use backstopjs:
 
 You can install backstop by entering this directory:


### PR DESCRIPTION
Related to this: https://docs.pantheon.io/guides/account-mgmt/plans/site-plans#bypassing-the-interstitial-page-with-an-http-header-during-automated-testing

VRT doesn't work on new sites because the test just sees the pantheon interstitial page instead of the page content.